### PR TITLE
fix: goのroot directoryを変更する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	google.golang.org/grpc v1.37.0
 	google.golang.org/protobuf v1.26.0
 )
+
+replace github.com/CA22-game-creators/cookingbomb-proto v0.1.0 => ./server/pb


### PR DESCRIPTION
## Issues
#4 
## About
goのroot directoryを変更する
## Background
他repositoryで`go get`できない
## Details
- `go.mod`の`replace`でexportするdirを明示

## Remarks
https://zenn.dev/shellyln/articles/b2992891f8f3f9381025
<img width="816" alt="スクリーンショット 2021-05-05 20 24 17" src="https://user-images.githubusercontent.com/38310693/117133942-dfdc4880-addf-11eb-801d-0f706691090d.png">
